### PR TITLE
Fix error spam when connection closes

### DIFF
--- a/src/main/java/me/armar/plugins/autorank/pathbuilder/playerdata/global/GlobalPlayerDataStorage.java
+++ b/src/main/java/me/armar/plugins/autorank/pathbuilder/playerdata/global/GlobalPlayerDataStorage.java
@@ -106,6 +106,7 @@ public class GlobalPlayerDataStorage implements PlayerDataStorage {
                     }
                 } catch (SQLException var8) {
                     var8.printStackTrace();
+                    break;
                 }
 
                 String serverName = null;


### PR DESCRIPTION
Implement a fix for when the `ResultSet` connection gets aborted in some setups

This might be due to a race condition and the fact that HikariCP only allows one `ResultSet` to be active at a time.

This fix makes it so that when `result.next()` throws an error such as:
```
java.sql.SQLException: Operation not allowed after ResultSet closed
[00:00:00] [Craft Scheduler Thread - 8444 - Autorank/WARN]:     at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)
[00:00:00] [Craft Scheduler Thread - 8444 - Autorank/WARN]:     at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
[00:00:00] [Craft Scheduler Thread - 8444 - Autorank/WARN]:     at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:89)
[00:00:00] [Craft Scheduler Thread - 8444 - Autorank/WARN]:     at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:63)
[00:00:00] [Craft Scheduler Thread - 8444 - Autorank/WARN]:     at com.mysql.cj.jdbc.result.ResultSetImpl.checkClosed(ResultSetImpl.java:464)
[00:00:00] [Craft Scheduler Thread - 8444 - Autorank/WARN]:     at com.mysql.cj.jdbc.result.ResultSetImpl.next(ResultSetImpl.java:1744)
[00:00:00] [Craft Scheduler Thread - 8444 - Autorank/WARN]:     at Autorank.jar//com.zaxxer.hikari.pool.HikariProxyResultSet.next(HikariProxyResultSet.java)
[00:00:00] [Craft Scheduler Thread - 8444 - Autorank/WARN]:     at Autorank.jar//me.armar.plugins.autorank.pathbuilder.playerdata.global.GlobalPlayerDataStorage.updateCacheFromRemote(GlobalPlayerDataStorage.java:104)
```

But, since we never break out of the loop, we'd just keep spamming this log error until the server crashes due to 100GB of logs

This fix lets us try again later, and even if we miss some, it's better than a full crash and possible file corruption